### PR TITLE
Can not run on Visual Studio 2022, always get debugging error with exit code 9009 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.clw
 
 # VB6 Files
-*.scc
+
 *.vbw
 *.pdb
 *.log


### PR DESCRIPTION
I want to run the project on Visual Studio 2022 but unfortunately it's not working it's give me the error "exited with code 9009" during this build? Actually, I want test the code and launch wcFinder TestApp itself in different DPI-awareness context, pass parameter 0, 1, or 2.